### PR TITLE
Have makefile list all avalible targets when no target specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ endif
 # arguments is going to be nondestructive. The @ is to silence the normal make
 # behavior of echo'ing commands before running them.
 faketarget:
-	@echo "Please specify a target. See README for available targets."
+	@echo "Please specify a target. See README for information about targets."
+	@grep Makefile -oe '^[a-z-]*:' | \
+	 tr -d ':' | \
+	 grep -v 'fake' | \
+	 sed -e 's/^/\o033[32m->\o033[0m /'
 
 init: salt composer-install docker-start ready init-drupal docker-status
 


### PR DESCRIPTION
make will now list all available targets when no target is specified :+1: 


The following is an example output

```bash
user@localhost$ make
Please specify a target. See README for information about targets.
-> init
-> init-drupal
-> update
-> safe-update
-> docker-rebuild
-> docker-status
-> docker-start
-> docker-stop
-> composer-install
-> composer-update
-> drupal-upgrade
-> drupal-install
-> config-init
-> config-import
-> config-export
-> config-validate
-> config-refresh
-> salt
-> clear-cache
-> destroy
-> rebuild
-> ready
-> lint
-> sniff
-> code-test
-> code-fix
-> fix-permissions
```