### PR TITLE
Disable composer root warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 faketarget:
 	@echo "Please specify a target. See README for available targets."
 
-init: salt composer-install docker-start ready init-drupal docker-status
+init: salt docker-start ready composer-install init-drupal docker-status
 
 init-drupal: drupal-install config-init config-import clear-cache
 
@@ -36,13 +36,13 @@ docker-stop:
 	docker-compose -f ${DOCKER_COMPOSE_FILE} down
 
 composer-install:
-	composer install --ignore-platform-reqs --no-interaction --no-progress
+	./bin/composer install --ignore-platform-reqs --no-interaction --no-progress
 
 composer-update:
-	composer update --ignore-platform-reqs --no-interaction --no-progress --prefer-dist
+	./bin/composer update --ignore-platform-reqs --no-interaction --no-progress --prefer-dist
 
 drupal-upgrade:
-	composer update drupal/core --with-dependencies
+	./bin/composer update drupal/core --with-dependencies
 
 drupal-install:
 	./bin/drush --root=/var/www/web site-install minimal -vv --account-name=admin --account-pass=admin --yes \

--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+PARAMS=""
+
+for PARAM in "$@"
+do
+  PARAMS="${PARAMS} \"${PARAM}\""
+done
+
+docker exec -it cms sh -c " /usr/local/bin/composer --working-dir=/var/www ${PARAMS}"

--- a/docker-src/cms/Dockerfile
+++ b/docker-src/cms/Dockerfile
@@ -56,4 +56,6 @@ RUN [ -e /etc/apache2/sites-enabled/000-default.conf ] && sed -i -e "s/\/var\/ww
   || sed -i -e "s/\/var\/www\/html/\/var\/www\/web/" /etc/apache2/apache2.conf \
   && [ -e /etc/apache2/sites-enabled/default-ssl.conf ] && sed -i -e "s/\/var\/www\/html/\/var\/www\/web/" /etc/apache2/sites-enabled/default-ssl.conf
 
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
 WORKDIR /var/www


### PR DESCRIPTION
Run composer inside container. This may make 'syncing' on the mac faster.

Remove warning for running composer as root. Its ok in a docker container per https://getcomposer.org/doc/03-cli.md#composer-allow-superuser