### PR TITLE
ignore libraries folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 drush/contrib
 vendor
 web/core
+web/libraries
 web/modules/contrib
 web/themes/contrib
 web/profiles/contrib


### PR DESCRIPTION
This folder is already setup to be blown away in the 'make destroy' command. 