### PR TITLE
Make 'destory' command remove images assosiated with this project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clear-cache:
 	./bin/drush cr
 
 destroy:
-	docker-compose -f ${DOCKER_COMPOSE_FILE} down -v
+	docker-compose -f ${DOCKER_COMPOSE_FILE} down -v --rmi 'all'
 	sudo rm -rf ./web/sites/default/files/*
 	sudo rm -rf ./web/core/*
 	sudo rm -rf ./web/libraries/*


### PR DESCRIPTION
Tested this on my system. Doesn't remove "all" images only images related to this docker-compose file.