### PR TITLE
Fix many host-container permission issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,11 @@ services:
       - connector
     volumes:
       - "./composer.json:/var/www/composer.json"
-      - "./webroot:/var/www/webroot"
-      - "./config:/var/www/config"
-      - "./vendor:/var/www/vendor"
-      - "./tests:/var/www/tests"
+      - "./webroot:/var/www-host/webroot"
+      - "./config:/var/www-host/config"
+      - "./vendor:/var/www-host/vendor"
+      - "./tests:/var/www-host/tests"
+    privileged: true
 
   web:
     build:
@@ -43,7 +44,8 @@ services:
     depends_on:
       - php
     volumes:
-      - "./webroot:/var/www/webroot:ro"
+      - "./webroot:/var/www/webroot-host:ro"
+    privileged: true
 
   db:
     image: percona:5

--- a/docker-src/cms/90-bindfs-webroot.sh
+++ b/docker-src/cms/90-bindfs-webroot.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+ bindfs --force-user=nginx --force-group=nginx --create-for-user=1000 --create-for-group=1000 --chown-ignore --chgrp-ignore /var/www/webroot-host /var/www/webroot

--- a/docker-src/cms/Dockerfile
+++ b/docker-src/cms/Dockerfile
@@ -1,3 +1,9 @@
+FROM alpine:edge as alpine-edge
+RUN set -ex \
+  && apk add --no-cache --virtual .build-bindfs \
+                --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+                bindfs
+
 #------------------------------------------------------------------------------
 # PHP BASE
 #------------------------------------------------------------------------------
@@ -85,6 +91,13 @@ COPY docker-src/cms/php-conf.d/* /usr/local/etc/php/conf.d/
 #------------------------------------------------------------------------------
 FROM nginx:stable-alpine as web-dev
 
+RUN set -ex \
+  && apk add --no-cache --virtual .build-bindfs \
+                fuse3-libs fuse
+COPY --from=alpine-edge /usr/bin/bindfs /usr/bin/bindfs
+COPY docker-src/cms/90-bindfs-webroot.sh /docker-entrypoint.d/90-bindfs-webroot.sh
+RUN chmod 774 /docker-entrypoint.d/90-bindfs-webroot.sh
+
 RUN rm /etc/nginx/conf.d/default.conf
 COPY ./docker-src/cms/nginx/ssl-cert-snakeoil.key /etc/nginx/private.key
 COPY ./docker-src/cms/nginx/ssl-cert-snakeoil.pem /etc/nginx/public.pem
@@ -97,6 +110,11 @@ WORKDIR /var/www/webroot
 #------------------------------------------------------------------------------
 FROM scratch as php-dev
 COPY --from=php-base . /
+
+RUN set -ex \
+  && apk add --no-cache --virtual .build-bindfs \
+                fuse3-libs fuse
+COPY --from=alpine-edge /usr/bin/bindfs /usr/bin/bindfs
 
 ENV PHP_INI_DIR /usr/local/etc/php
 ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-group=www-data --disable-cgi

--- a/docker-src/cms/entrypoint
+++ b/docker-src/cms/entrypoint
@@ -1,6 +1,19 @@
 #!/bin/sh
 set -e
 
+# make directories to mount against
+# webroot already exists
+mkdir /var/www/config
+mkdir /var/www/vendor
+mkdir /var/www/tests
+
+# use bindfs to map host user to www-data. This way any files created in the
+# container or outside are the correct permissions in their respective locations
+bindfs --force-user=www-data --force-group=www-data --create-for-user=1000 --create-for-group=1000 --chown-ignore --chgrp-ignore /var/www-host/webroot /var/www/webroot
+bindfs --force-user=www-data --force-group=www-data --create-for-user=1000 --create-for-group=1000 --chown-ignore --chgrp-ignore /var/www-host/config /var/www/config
+bindfs --force-user=www-data --force-group=www-data --create-for-user=1000 --create-for-group=1000 --chown-ignore --chgrp-ignore /var/www-host/vendor /var/www/vendor
+bindfs --force-user=www-data --force-group=www-data --create-for-user=1000 --create-for-group=1000 --chown-ignore --chgrp-ignore /var/www-host/tests /var/www/tests
+
 ln -sf /var/www/vendor/bin/* /bin/
 
 # Source file


### PR DESCRIPTION
Use bindfs to map user and group permissions for the mounted volumes. Thus permissions are always as desired on both the host and container.

Fixes #39